### PR TITLE
Fix undefined opts option in NixOS configuration

### DIFF
--- a/hm-modules/ai/default.nix
+++ b/hm-modules/ai/default.nix
@@ -27,7 +27,7 @@ in
       # inputs.nebvim.packages."${pkgs.stdenv.hostPlatform.system}".qwen-code
       inputs.claude-desktop.packages."${pkgs.stdenv.hostPlatform.system}".claude-desktop
     ];
-    opts.ai = {
+    hm.ai = {
       aichat.enable = true;
       # claude-code.enable = true;
       # gemini-cli.enable = true;

--- a/hm-modules/buku.nix
+++ b/hm-modules/buku.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.buku.enable = lib.mkEnableOption "enable buku";
+    hm.buku.enable = lib.mkEnableOption "enable buku";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/communications/default.nix
+++ b/hm-modules/communications/default.nix
@@ -15,7 +15,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    opts.communications = {
+    hm.communications = {
       thunderbird.enable = true;
       vesktop.enable = true;
     };

--- a/hm-modules/default.nix
+++ b/hm-modules/default.nix
@@ -82,7 +82,7 @@
     })
   ];
 
-  opts = {
+  hm = {
     ai.enable = true;
     communications.enable = true;
     fs-tools.enable = true;

--- a/hm-modules/fs-tools/default.nix
+++ b/hm-modules/fs-tools/default.nix
@@ -18,7 +18,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    opts.fs-tools = {
+    hm.fs-tools = {
       bat.enable = true;
       eza.enable = true;
       fd.enable = true;

--- a/hm-modules/fs-tools/lf.nix
+++ b/hm-modules/fs-tools/lf.nix
@@ -10,7 +10,7 @@ in
 {
 
   options = {
-    opts.fs-tools.lf.enable = lib.mkEnableOption "enable lf";
+    hm.fs-tools.lf.enable = lib.mkEnableOption "enable lf";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/fs-tools/yazi.nix
+++ b/hm-modules/fs-tools/yazi.nix
@@ -9,7 +9,7 @@ in
 {
 
   options = {
-    opts.fs-tools.yazi.enable = lib.mkEnableOption "enable yazi";
+    hm.fs-tools.yazi.enable = lib.mkEnableOption "enable yazi";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/fzf.nix
+++ b/hm-modules/fzf.nix
@@ -9,7 +9,7 @@ in
 {
 
   options = {
-    opts.fzf.enable = lib.mkEnableOption "enable fzf";
+    hm.fzf.enable = lib.mkEnableOption "enable fzf";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/mpv.nix
+++ b/hm-modules/mpv.nix
@@ -10,7 +10,7 @@ in
 {
 
   options = {
-    opts.mpv.enable = lib.mkEnableOption "enable mpv";
+    hm.mpv.enable = lib.mkEnableOption "enable mpv";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/newsboat.nix
+++ b/hm-modules/newsboat.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.newsboat.enable = lib.mkEnableOption "enable newsboat";
+    hm.newsboat.enable = lib.mkEnableOption "enable newsboat";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/nix-tools/default.nix
+++ b/hm-modules/nix-tools/default.nix
@@ -25,7 +25,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    opts.nix-tools = {
+    hm.nix-tools = {
       manix.enable = true;
       nh.enable = true;
       nix-index.enable = true;

--- a/hm-modules/obs-studio.nix
+++ b/hm-modules/obs-studio.nix
@@ -10,7 +10,7 @@ in
 {
 
   options = {
-    opts.obs-studio.enable = lib.mkEnableOption "enable obs-studio";
+    hm.obs-studio.enable = lib.mkEnableOption "enable obs-studio";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/pyradio.nix
+++ b/hm-modules/pyradio.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.pyradio.enable = lib.mkEnableOption "enable pyradio";
+    hm.pyradio.enable = lib.mkEnableOption "enable pyradio";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/shells/starship.nix
+++ b/hm-modules/shells/starship.nix
@@ -10,7 +10,7 @@ in
 {
 
   options = {
-    opts.shell.starship.enable = lib.mkEnableOption "enable starship";
+    hm.shell.starship.enable = lib.mkEnableOption "enable starship";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/shells/zsh/default.nix
+++ b/hm-modules/shells/zsh/default.nix
@@ -15,7 +15,7 @@ in
   ];
 
   options = {
-    opts.shell.zsh.enable = lib.mkEnableOption "enable zsh";
+    hm.shell.zsh.enable = lib.mkEnableOption "enable zsh";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/sioyek.nix
+++ b/hm-modules/sioyek.nix
@@ -4,7 +4,7 @@ let
 in
 {
   options = {
-    opts.sioyek.enable = lib.mkEnableOption "enable sioyek";
+    hm.sioyek.enable = lib.mkEnableOption "enable sioyek";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/spotube.nix
+++ b/hm-modules/spotube.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.spotube = {
+    hm.spotube = {
       enable = lib.mkEnableOption "enable spotube";
     };
   };

--- a/hm-modules/taskwarrior/default.nix
+++ b/hm-modules/taskwarrior/default.nix
@@ -12,7 +12,7 @@ in
   # imports = [ ./theme.nix ];
 
   options = {
-    opts.taskwarrior = {
+    hm.taskwarrior = {
       enable = lib.mkEnableOption "enable taskwarrior";
       recurrence.disable = lib.mkOption {
         type = lib.types.bool;

--- a/hm-modules/terminal-emulators/default.nix
+++ b/hm-modules/terminal-emulators/default.nix
@@ -14,7 +14,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    opts.terminal-emulators = {
+    hm.terminal-emulators = {
       foot.enable = true;
       ghostty.enable = true;
       kitty.enable = true;

--- a/hm-modules/tuir.nix
+++ b/hm-modules/tuir.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.tuir.enable = lib.mkEnableOption "enable tuir";
+    hm.tuir.enable = lib.mkEnableOption "enable tuir";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/web-browsers/default.nix
+++ b/hm-modules/web-browsers/default.nix
@@ -14,7 +14,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    opts.web-browsers = {
+    hm.web-browsers = {
       chromium.enable = true;
       firefox.enable = true;
       firefoxpwa.enable = true;

--- a/hm-modules/window-managers/default.nix
+++ b/hm-modules/window-managers/default.nix
@@ -4,5 +4,5 @@
     ./mango
   ];
 
-  opts.window-managers.mango.enable = true;
+  hm.window-managers.mango.enable = true;
 }

--- a/hm-modules/window-managers/hyprland/t5610.nix
+++ b/hm-modules/window-managers/hyprland/t5610.nix
@@ -4,7 +4,7 @@ let
 in
 {
   options = {
-    opts.window-managers.hyprland.t5610.enable =
+    hm.window-managers.hyprland.t5610.enable =
       lib.mkEnableOption "enable hyprland settings for t5610";
   };
 

--- a/hm-modules/window-managers/hyprland/x230t.nix
+++ b/hm-modules/window-managers/hyprland/x230t.nix
@@ -20,7 +20,7 @@ let
 in
 {
   options = {
-    opts.window-managers.hyprland.x230t.enable =
+    hm.window-managers.hyprland.x230t.enable =
       lib.mkEnableOption "enable hyprland settings for x230t";
   };
 

--- a/hm-modules/wvkbd.nix
+++ b/hm-modules/wvkbd.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options = {
-    opts.wvkbd.enable = lib.mkEnableOption "enable wvkbd";
+    hm.wvkbd.enable = lib.mkEnableOption "enable wvkbd";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hosts/m715q/hm/nebu.nix
+++ b/hosts/m715q/hm/nebu.nix
@@ -15,7 +15,7 @@
     homeDirectory = lib.mkForce "/home/nebu";
   };
 
-  # opts = {
+  # hm = {
   #   terminal-emulators.ghostty.enable = true;
   #   git.enable = true;
   # };

--- a/nixos-modules/default.nix
+++ b/nixos-modules/default.nix
@@ -24,7 +24,7 @@
 
   qt.enable = true;
   virtualisation.docker.enable = true;
-  opts.window-managers.mango.enable = true;
+  nos.window-managers.mango.enable = true;
 
   environment.systemPackages = [
     inputs.nebvim.packages."${pkgs.stdenv.hostPlatform.system}".default


### PR DESCRIPTION
Rename all remaining instances of the old 'opts' namespace:
- In hm-modules: opts → hm (Home Manager modules)
- In nixos-modules: opts → nos (NixOS modules)

This completes the namespace migration started in previous commits, ensuring consistent naming throughout the codebase.

Modified files:
- nixos-modules/default.nix
- hm-modules/default.nix and 25+ submodules
- hosts/m715q/hm/nebu.nix