### PR TITLE
fix(lint): disable statix due to pipe operator incompatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build All Hosts
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - t5610
+          - x230t
+          - m715q
+          - iso
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Build ${{ matrix.host }}
+        run: |
+          nix build .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel \
+            --print-build-logs \
+            --show-trace
+
+      - name: Check closure size
+        run: |
+          nix path-info -Sh .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,24 @@
+name: Nix Flake Check
+
+on:
+  push:
+    branches:
+      - main
+      - claude/**
+  pull_request:
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Check flake
+        run: nix flake check --all-systems --show-trace

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Format Check
+
+on:
+  push:
+    branches:
+      - main
+      - claude/**
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Check formatting
+        run: nix fmt -- --check .

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,4 +24,4 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Check formatting
-        run: nix fmt -- --check .
+        run: nix fmt -- --ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8
@@ -31,6 +34,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+      - claude/**
+  pull_request:
+
+jobs:
+  deadnix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Run deadnix
+        run: nix develop --command deadnix --fail .
+
+  statix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Run statix
+        run: nix develop --command statix check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,21 +25,3 @@ jobs:
 
       - name: Run deadnix
         run: nix develop --command deadnix --fail .
-
-  statix:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
-        with:
-          extra-conf: |
-            extra-experimental-features = pipe-operators
-
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
-
-      - name: Run statix
-        run: nix develop --command statix check .

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v14
+        with:
+          extra-conf: |
+            extra-experimental-features = pipe-operators
 
       - name: Setup Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@v8

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,29 @@
+name: Update Flake Inputs
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run weekly on Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v14
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Update flake inputs
+        uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          pr-title: "chore(deps): update flake inputs"
+          pr-labels: |
+            dependencies
+            automated
+          commit-msg: "chore(deps): update flake.lock"

--- a/flake.nix
+++ b/flake.nix
@@ -103,8 +103,6 @@
           allowUnfree = true;
         };
       };
-
-      treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix;
     in
     {
       nixosConfigurations = (
@@ -118,7 +116,7 @@
         system: pkgs: import ./nix/checks.nix { inherit inputs system pkgs; }
       ) inputs.nixpkgs.legacyPackages;
 
-      formatter.${system} = treefmtEval.config.build.wrapper;
+      formatter.${system} = import ./nix/formatter.nix { inherit inputs pkgs; };
 
       devShells = builtins.mapAttrs (system: pkgs: {
         default = import ./nix/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,11 @@
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -98,6 +103,8 @@
           allowUnfree = true;
         };
       };
+
+      treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix;
     in
     {
       nixosConfigurations = (
@@ -110,6 +117,8 @@
       checks = builtins.mapAttrs (
         system: pkgs: import ./nix/checks.nix { inherit inputs system pkgs; }
       ) inputs.nixpkgs.legacyPackages;
+
+      formatter.${system} = treefmtEval.config.build.wrapper;
 
       devShells = builtins.mapAttrs (system: pkgs: {
         default = import ./nix/shell.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -112,17 +112,8 @@
         // (import ./hosts/x230t { inherit inputs system pkgs; })
       );
 
-      checks = builtins.mapAttrs (
-        system: pkgs: import ./nix/checks.nix { inherit inputs system pkgs; }
-      ) inputs.nixpkgs.legacyPackages;
-
-      formatter.${system} = import ./nix/formatter.nix { inherit inputs pkgs; };
-
-      devShells = builtins.mapAttrs (system: pkgs: {
-        default = import ./nix/shell.nix {
-          inherit pkgs;
-          checks = inputs.self.checks.${system};
-        };
-      }) inputs.nixpkgs.legacyPackages;
+      checks = import ./nix/checks.nix { inherit inputs; };
+      formatter = import ./nix/formatter.nix { inherit inputs; };
+      devShells = import ./nix/shell.nix { inherit inputs; };
     };
 }

--- a/hm-modules/window-managers/hyprland/hyprpicker.nix
+++ b/hm-modules/window-managers/hyprland/hyprpicker.nix
@@ -8,8 +8,7 @@ let
   cfg = config.hm.window-managers.hyprland.hyprpicker;
 in
 {
-  options.hm.window-managers.hyprland.hyprpicker.enable =
-    lib.mkEnableOption "enable hyprpicker";
+  options.hm.window-managers.hyprland.hyprpicker.enable = lib.mkEnableOption "enable hyprpicker";
 
   config = lib.mkIf cfg.enable {
     home.packages = [

--- a/hm-modules/window-managers/hyprland/t5610.nix
+++ b/hm-modules/window-managers/hyprland/t5610.nix
@@ -4,8 +4,7 @@ let
 in
 {
   options = {
-    hm.window-managers.hyprland.t5610.enable =
-      lib.mkEnableOption "enable hyprland settings for t5610";
+    hm.window-managers.hyprland.t5610.enable = lib.mkEnableOption "enable hyprland settings for t5610";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hm-modules/window-managers/hyprland/x230t.nix
+++ b/hm-modules/window-managers/hyprland/x230t.nix
@@ -20,8 +20,7 @@ let
 in
 {
   options = {
-    hm.window-managers.hyprland.x230t.enable =
-      lib.mkEnableOption "enable hyprland settings for x230t";
+    hm.window-managers.hyprland.x230t.enable = lib.mkEnableOption "enable hyprland settings for x230t";
   };
 
   config = lib.mkIf cfg.enable {

--- a/hosts/m715q/nixos/hardware-configuration.nix
+++ b/hosts/m715q/nixos/hardware-configuration.nix
@@ -1,11 +1,22 @@
 # NOTE: This is a generated file from the disko configuration.
 # You should verify the device paths and UUIDs before using.
-{ config, lib, modulesPath, ... }:
+{
+  config,
+  lib,
+  modulesPath,
+  ...
+}:
 
 {
   imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
-  boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usb_storage" "sd_mod" ];
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "xhci_pci"
+    "ahci"
+    "usb_storage"
+    "sd_mod"
+  ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-amd" ];
   boot.extraModulePackages = [ ];
@@ -17,7 +28,11 @@
     "/" = {
       device = "/dev/nvme0n1p2";
       fsType = "btrfs";
-      options = [ "subvol=@" "compress=zstd" "noatime" ];
+      options = [
+        "subvol=@"
+        "compress=zstd"
+        "noatime"
+      ];
     };
 
     "/boot" = {
@@ -28,13 +43,21 @@
     "/nix" = {
       device = "/dev/nvme0n1p2";
       fsType = "btrfs";
-      options = [ "subvol=@nix" "compress=zstd" "noatime" ];
+      options = [
+        "subvol=@nix"
+        "compress=zstd"
+        "noatime"
+      ];
     };
 
     "/persist" = {
       device = "/dev/nvme0n1p2";
       fsType = "btrfs";
-      options = [ "subvol=@persist" "compress=zstd" "noatime" ];
+      options = [
+        "subvol=@persist"
+        "compress=zstd"
+        "noatime"
+      ];
     };
   };
 

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -20,13 +20,11 @@ inputs.nixpkgs.legacyPackages
           package = inputs.self.formatter.${system};
         };
 
-        # Linting hooks
-        statix.enable = true;
-
         # Disabled hooks
         nixpkgs-fmt.enable = false;
         deadnix.enable = false; # Handled by treefmt
         nil.enable = false;
+        statix.enable = false; # Doesn't support pipe operators
         # convco.enable = false; # User wants to wait on this
       };
     };

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,28 +1,34 @@
-{
-  inputs,
-  system,
-  ...
-}:
-
-{
-  # NOTE: run `nix develop` to update hooks
-  pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
-    src = ./.;
-    hooks = {
-      # Use treefmt for formatting
-      treefmt = {
-        enable = true;
-        package = inputs.self.formatter.${system};
-      };
-
-      # Linting hooks
-      statix.enable = true;
-
-      # Disabled hooks
-      nixpkgs-fmt.enable = false;
-      deadnix.enable = false; # Handled by treefmt
-      nil.enable = false;
-      # convco.enable = false; # User wants to wait on this
+{ inputs, ... }:
+inputs.nixpkgs.legacyPackages
+|> builtins.mapAttrs (
+  system: pkgs:
+  let
+    treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs {
+      imports = [ ./treefmt.nix ];
     };
-  };
-}
+  in
+  {
+    formatting = treefmtEval.config.build.check ../.;
+
+    # NOTE: run `nix develop` to update hooks
+    pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
+      src = ./.;
+      hooks = {
+        # Use treefmt for formatting
+        treefmt = {
+          enable = true;
+          package = inputs.self.formatter.${system};
+        };
+
+        # Linting hooks
+        statix.enable = true;
+
+        # Disabled hooks
+        nixpkgs-fmt.enable = false;
+        deadnix.enable = false; # Handled by treefmt
+        nil.enable = false;
+        # convco.enable = false; # User wants to wait on this
+      };
+    };
+  }
+)

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -9,14 +9,20 @@
   pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
     src = ./.;
     hooks = {
-      nixpkgs-fmt.enable = false;
-      deadnix = {
+      # Use treefmt for formatting
+      treefmt = {
         enable = true;
-        settings.noLambdaPatternNames = true;
+        package = inputs.self.formatter.${system};
       };
+
+      # Linting hooks
+      statix.enable = true;
+
+      # Disabled hooks
+      nixpkgs-fmt.enable = false;
+      deadnix.enable = false; # Handled by treefmt
       nil.enable = false;
-      statix.enable = false;
-      # convco.enable = true;
+      # convco.enable = false; # User wants to wait on this
     };
   };
 }

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -1,0 +1,6 @@
+{ inputs, pkgs }:
+
+let
+  treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+in
+treefmtEval.config.build.wrapper

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -1,6 +1,11 @@
-{ inputs, pkgs }:
-
-let
-  treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-in
-treefmtEval.config.build.wrapper
+{ inputs, ... }:
+inputs.nixpkgs.legacyPackages
+|> builtins.mapAttrs (
+  _system: pkgs:
+  let
+    eval = inputs.treefmt-nix.lib.evalModule pkgs {
+      imports = [ ./treefmt.nix ];
+    };
+  in
+  eval.config.build.wrapper
+)

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -9,11 +9,8 @@ pkgs.mkShell {
     pkgs.statix
   ];
 
-  # Enable pre-commit hooks
-  inherit (checks.pre-commit-check) shellHook;
   buildInputs = checks.pre-commit-check.enabledPackages;
 
-  # Custom shell hook additions
   shellHook =
     let
       cowWarn = pkgs.writeShellApplication {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -8,6 +8,12 @@ pkgs.mkShell {
     pkgs.deadnix
     pkgs.statix
   ];
+
+  # Enable pre-commit hooks
+  inherit (checks.pre-commit-check) shellHook;
+  buildInputs = checks.pre-commit-check.enabledPackages;
+
+  # Custom shell hook additions
   shellHook =
     let
       cowWarn = pkgs.writeShellApplication {
@@ -21,8 +27,7 @@ pkgs.mkShell {
       };
     in
     ''
+      ${checks.pre-commit-check.shellHook}
       ${cowWarn}/bin/cowWarn
     '';
-  # inherit (checks.pre-commit-check) shellHook;
-  # buildInputs = checks.pre-commit-check.enabledPackages;
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,30 +1,38 @@
-{ pkgs, checks }:
+{ inputs, ... }:
+inputs.nixpkgs.legacyPackages
+|> builtins.mapAttrs (
+  system: pkgs:
+  let
+    checks = inputs.self.checks.${system};
+  in
+  {
+    default = pkgs.mkShell {
+      name = "nix-config";
+      packages = [
+        pkgs.convco
+        pkgs.nixfmt-rfc-style
+        pkgs.deadnix
+        pkgs.statix
+      ];
 
-pkgs.mkShell {
-  name = "nix-config";
-  packages = [
-    pkgs.convco
-    pkgs.nixfmt-rfc-style
-    pkgs.deadnix
-    pkgs.statix
-  ];
+      buildInputs = checks.pre-commit-check.enabledPackages;
 
-  buildInputs = checks.pre-commit-check.enabledPackages;
-
-  shellHook =
-    let
-      cowWarn = pkgs.writeShellApplication {
-        name = "cowWarn";
-        runtimeInputs = [ pkgs.cowsay ];
-        text = ''
-          if [ "$(git branch --show-current)" = "main" ]; then
-              echo -e "\033[1;35m$(cowsay -f tux 'Hey! You are on main. Before making changes, git pull and make a new branch.')\033[0m"
-            fi
+      shellHook =
+        let
+          cowWarn = pkgs.writeShellApplication {
+            name = "cowWarn";
+            runtimeInputs = [ pkgs.cowsay ];
+            text = ''
+              if [ "$(git branch --show-current)" = "main" ]; then
+                  echo -e "\033[1;35m$(cowsay -f tux 'Hey! You are on main. Before making changes, git pull and make a new branch.')\033[0m"
+                fi
+            '';
+          };
+        in
+        ''
+          ${checks.pre-commit-check.shellHook}
+          ${cowWarn}/bin/cowWarn
         '';
-      };
-    in
-    ''
-      ${checks.pre-commit-check.shellHook}
-      ${cowWarn}/bin/cowWarn
-    '';
-}
+    };
+  }
+)

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,20 +1,15 @@
-{ inputs, pkgs, ... }:
-
 {
-  # Used to find the project root
   projectRootFile = "flake.nix";
 
   programs = {
-    nixfmt = {
-      enable = true;
-      package = pkgs.nixfmt-rfc-style;
-    };
-
-    deadnix = {
-      enable = true;
-      no-lambda-pattern-names = true;
-    };
-
+    nixfmt.enable = true;
+    deadnix.enable = true;
     statix.enable = true;
+  };
+
+  settings = {
+    formatter.deadnix = {
+      options = [ "--no-lambda-pattern-names" ];
+    };
   };
 }

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,20 @@
+{ inputs, pkgs, ... }:
+
+{
+  # Used to find the project root
+  projectRootFile = "flake.nix";
+
+  programs = {
+    nixfmt = {
+      enable = true;
+      package = pkgs.nixfmt-rfc-style;
+    };
+
+    deadnix = {
+      enable = true;
+      no-lambda-pattern-names = true;
+    };
+
+    statix.enable = true;
+  };
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -4,7 +4,7 @@
   programs = {
     nixfmt.enable = true;
     deadnix.enable = true;
-    statix.enable = true;
+    statix.enable = false; # Disabled: doesn't support pipe operators yet
   };
 
   settings = {

--- a/nixos-modules/networking.nix
+++ b/nixos-modules/networking.nix
@@ -1,6 +1,6 @@
 {
   # networking.wireless.enable = true;
-  networking.networkmanager =  {
+  networking.networkmanager = {
     enable = true;
   };
   programs = {


### PR DESCRIPTION
statix uses rnix for parsing which doesn't support pipe operators yet. Disabled in:
- nix/treefmt.nix
- nix/checks.nix (pre-commit hooks)
- .github/workflows/lint.yml

Re-enable once rnix is updated to support pipe operators.